### PR TITLE
Change Singapore dollar symbol to S$.

### DIFF
--- a/isodata.tsv
+++ b/isodata.tsv
@@ -126,7 +126,7 @@ SBD	090	Solomon Islands dollar	SB	S$		100
 SCR	690	Seychelles rupee	SC	SRe		100
 SDG	938	Sudanese pound	SD	¤		100
 SEK	752	Swedish krona/kronor	SE	kr		100
-SGD	702	Singapore dollar	SG	¤		100
+SGD	702	Singapore dollar	SG	S$		100
 SHP	654	Saint Helena pound	SH	£		100
 SLL	694	Sierra Leonean leone	SL	Le		100
 SOS	706	Somali shilling	SO	Sh.So.		100


### PR DESCRIPTION
I believe the right symbol for the Singapore dollar is S$ - I could not see `¤` used anywhere. The wikipedia page for the Singapore dollar mentions `S$` or just `$` as the symbol.