### PR TITLE
Allow Currency variants to be sorted lexicographically

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,7 +50,7 @@ fn read_table() -> Vec<IsoData> {
 
 fn write_enum(file: &mut BufWriter<File>, data: &Vec<IsoData>) {
     writeln!(file, "#[cfg_attr(feature = \"with-serde\", derive(Serialize, Deserialize))]").unwrap();
-    writeln!(file, "#[derive(Clone, Copy, PartialEq, Eq, Hash)]").unwrap();
+    writeln!(file, "#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]").unwrap();
     writeln!(file, "pub enum Currency {{").unwrap();
 
     for currency in data.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,4 +169,11 @@ mod tests {
 
         assert_eq!(serde_json::to_string(&hashmap).unwrap(), "{\"foo\":\"EUR\"}");
     }
+
+    #[test]
+    fn can_be_sorted() {
+        let mut v = vec![Currency::SEK, Currency::DKK, Currency::EUR];
+        v.sort();
+        assert_eq!(v, vec![Currency::DKK, Currency::EUR, Currency::SEK]);
+    }
 }


### PR DESCRIPTION
Useful when the currency is a field in a struct and the struct needs to implement `PartialOrd` and/or `Ord`.