### PR TITLE
Update subunit_fraction for CNY

### DIFF
--- a/isodata.tsv
+++ b/isodata.tsv
@@ -32,7 +32,7 @@ CHF	756	Swiss franc	CH;LI	₣		100
 CHW	948	WIR Franc	CH	¤		100
 CLF	990	Unidad de Fomento	CL	¤		100
 CLP	152	Chilean peso	CL	$		100
-CNY	156	Renminbi (Chinese) yuan	CN	¥		10
+CNY	156	Renminbi (Chinese) yuan	CN	¥		100
 COP	170	Colombian peso	CO	$		100
 COU	970	Unidad de Valor Real (UVR)	CO	¤		100
 CRC	188	Costa Rican colon	CR	₡		100


### PR DESCRIPTION
From your suggestion here: https://github.com/zbrox/iso_currency/issues/12#issuecomment-1114709396, according to https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list_one.xml, the minor units divisor for CNY is `2` (equivalent to `100` in the format used here).

The discrepancy may stem from the fact that the yuan has _two_ subunits 1/10 and 1/100. It seems that the official source takes the _smallest_ one.