### PR TITLE
Add country mapping for Namibian dollar (`NAD`)

### DIFF
--- a/isodata.tsv
+++ b/isodata.tsv
@@ -102,7 +102,7 @@ MXN	484	Mexican peso	MX	$	¢	2
 MXV	979	Mexican Unidad de Inversion (UDI)	MX	¤		2
 MYR	458	Malaysian ringgit	MY	RM		2
 MZN	943	Mozambican metical	MZ	MT		2
-NAD	516	Namibian dollar		N$		2
+NAD	516	Namibian dollar		N$	NA	2
 NGN	566	Nigerian naira	NG	₦		2
 NIO	558	Nicaraguan córdoba	NI	C$		2
 NOK	578	Norwegian krone	NO;SJ;BV	kr		2


### PR DESCRIPTION
Note that Namibia is currently known to use the South African Rand (`ZAR`)