### PR TITLE
Add sqlx related features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,16 @@ default = []
 with-serde = ["dep:serde"]
 iterator = ["dep:strum"]
 with-schemars = ["dep:schemars", "with-serde"]
+with-sqlx-sqlite = ["dep:sqlx", "sqlx/sqlite"]
+with-sqlx-postgres = ["dep:sqlx", "sqlx/postgres"]
+with-sqlx-mysql = ["dep:sqlx", "sqlx/mysql"]
 
 [dependencies]
 iso_country = "0.1.4"
 schemars = { version = "0.8.16", optional = true }
 serde = { version = "1.0.127", optional = true, features = ["derive"] }
-strum = {version = "0.26.1", optional = true, features = ["derive"] }
+strum = { version = "0.26.1", optional = true, features = ["derive"] }
+sqlx = { version = ">0.7", optional = true}
 
 [dev-dependencies]
 divan = "0.1.11"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The crate has some optional features:
 - `with-serde`
 - `iterator`
 - `with-schemars`
+- `with-sqlx-sqlite`
+- `with-sqlx-postgres`
+- `with-sqlx-mysql`
 
 ### with-serde
 
@@ -42,6 +45,18 @@ let mut iter = Currency::iter();
 If you need to generate a JSON schema for your project, you can use the `with-schemars` feature. This will derive [`schemars's`](https://crates.io/crates/schemars) `JsonSchema` trait on `Currency`.
 
 **NOTE**: This feature enables `with-serde` as well.
+
+### with-sqlx-sqlite
+
+Implements the `Type` and `Decode` traits from [sqlx](https://github.com/launchbadge/sqlx) version >0.7 for SQLite on the `Currency` struct.
+
+### with-sqlx-postgres
+
+Implements the `Type` and `Decode` traits from [sqlx](https://github.com/launchbadge/sqlx) version >0.7 for PostgreSQL on the `Currency` struct.
+
+### with-sqlx-mysql
+
+Implements the `Type` and `Decode` traits from [sqlx](https://github.com/launchbadge/sqlx) version >0.7 for MySQL on the `Currency` struct.
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,54 @@ impl From<Country> for Currency {
     }
 }
 
+#[cfg(feature = "with-sqlx-sqlite")]
+impl sqlx::Decode<'_, sqlx::Sqlite> for Currency {
+    fn decode(value: sqlx::sqlite::SqliteValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        let code: String = sqlx::Decode::<'_, sqlx::Sqlite>::decode(value)?;
+        Currency::from_code(&code)
+            .ok_or_else(|| sqlx::error::BoxDynError::from("Invalid currency code"))
+    }
+}
+
+#[cfg(feature = "with-sqlx-sqlite")]
+impl sqlx::Type<sqlx::Sqlite> for Currency {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <String as sqlx::Type<sqlx::Sqlite>>::type_info()
+    }
+}
+
+#[cfg(feature = "with-sqlx-postgres")]
+impl sqlx::Decode<'_, sqlx::Postgres> for Currency {
+    fn decode(value: sqlx::postgres::PgValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        let code: String = sqlx::Decode::<'_, sqlx::Postgres>::decode(value)?;
+        Currency::from_code(&code)
+            .ok_or_else(|| sqlx::error::BoxDynError::from("Invalid currency code"))
+    }
+}
+
+#[cfg(feature = "with-sqlx-postgres")]
+impl sqlx::Type<sqlx::Postgres> for Currency {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <String as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+}
+
+#[cfg(feature = "with-sqlx-mysql")]
+impl sqlx::Decode<'_, sqlx::MySql> for Currency {
+    fn decode(value: sqlx::mysql::MySqlValueRef<'_>) -> Result<Self, sqlx::error::BoxDynError> {
+        let code: String = sqlx::Decode::<'_, sqlx::MySql>::decode(value)?;
+        Currency::from_code(&code)
+            .ok_or_else(|| sqlx::error::BoxDynError::from("Invalid currency code"))
+    }
+}
+
+#[cfg(feature = "with-sqlx-mysql")]
+impl sqlx::Type<sqlx::MySql> for Currency {
+    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        <String as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Country, Currency, Flag, ParseCurrencyError};


### PR DESCRIPTION
Add features which should make using the Currency struct directly with sqlx (using sqlite, postgres, or mysql) easier without wrappers.

Closes #33 