### PR TITLE
Add std::error::Error impl for ParseCurrencyError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ impl std::fmt::Display for ParseCurrencyError {
     }
 }
 
+impl std::error::Error for ParseCurrencyError {}
+
 impl std::fmt::Debug for CurrencySymbol {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.symbol)


### PR DESCRIPTION
https://github.com/zbrox/iso_currency/issues/39