### PR TITLE
with-specta feature to derive specta::Type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ with-schemars = ["dep:schemars", "with-serde"]
 with-sqlx-sqlite = ["dep:sqlx", "sqlx/sqlite"]
 with-sqlx-postgres = ["dep:sqlx", "sqlx/postgres"]
 with-sqlx-mysql = ["dep:sqlx", "sqlx/mysql"]
+with-specta = ["dep:specta", "with-serde"]
 
 [dependencies]
 iso_country = "0.1.4"
@@ -26,6 +27,7 @@ schemars = { version = "0.8.16", optional = true }
 serde = { version = "1.0.127", optional = true, features = ["derive"] }
 strum = { version = "0.27.1", optional = true, features = ["derive"] }
 sqlx = { version = ">0.7", optional = true }
+specta = { version = "2.0.0-rc.25", features = ["derive"], optional = true }
 
 [dev-dependencies]
 divan = "0.1.11"

--- a/build.rs
+++ b/build.rs
@@ -131,6 +131,7 @@ fn write_enum(file: &mut BufWriter<File>, data: &[IsoData]) {
         #[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
         #[cfg_attr(feature = "iterator", derive(EnumIter))]
         #[cfg_attr(feature = "with-schemars", derive(JsonSchema))]
+        #[cfg_attr(feature = "with-specta", derive(specta::Type))]
         #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub enum Currency {
             #body


### PR DESCRIPTION
Adding the derive for [specta](https://github.com/specta-rs/specta) as an optional feature.

Specta is a tool for exporting Rust types to other languages, so adding its derive would be great for using this crate in API signatures.

Note: specta is right around the release of v2, so it would make sense to wait until that happens so that the dependency is for v2 instead of a release candidate.
